### PR TITLE
WP CLI commands

### DIFF
--- a/admin/class-ucf-sanitizer-config.php
+++ b/admin/class-ucf-sanitizer-config.php
@@ -17,11 +17,9 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 			 * @var array The option default values
 			 */
 			$option_defaults = array(
-				// 'allowed_tags_on_save'            => '',
 				'enabled_post_types'              => array( 'post', 'page' ),
 				'cli_enable_postmaster_filtering' => true,
-				'cli_enable_safelink_filtering'   => true,
-				// 'cli_enable_tag_filtering'        => true
+				'cli_enable_safelink_filtering'   => true
 			);
 
 		/**
@@ -37,8 +35,6 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 			add_option( self::$options_prefix . 'enabled_post_types', $defaults['enabled_post_types'] );
 			add_option( self::$options_prefix . 'cli_enable_postmaster_filtering', $defaults['cli_enable_postmaster_filtering'] );
 			add_option( self::$options_prefix . 'cli_enable_safelink_filtering', $defaults['cli_enable_safelink_filtering'] );
-			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
-			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
 		}
 
 		/**
@@ -52,8 +48,6 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 			delete_option( self::$options_prefix . 'enabled_post_types' );
 			delete_option( self::$options_prefix . 'cli_enable_postmaster_filtering' );
 			delete_option( self::$options_prefix . 'cli_enable_safelink_filtering' );
-			// delete_option( self::$options_prefix . 'TODO' );
-			// delete_option( self::$options_prefix . 'TODO' );
 		}
 
 		/**
@@ -69,9 +63,7 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 			$configurable_defaults = array(
 				'enabled_post_types' => get_option( self::$options_prefix . 'enabled_post_types', $defaults['enabled_post_types'] ),
 				'cli_enable_postmaster_filtering' => get_option( self::$options_prefix . 'cli_enable_postmaster_filtering', $defaults['cli_enable_postmaster_filtering'] ),
-				'cli_enable_safelink_filtering' => get_option( self::$options_prefix . 'cli_enable_safelink_filtering', $defaults['cli_enable_safelink_filtering'] ),
-				// 'TODO' => get_option( self::$options_prefix . 'TODO', $defaults['TODO'] ),
-				// 'TODO' => get_option( self::$options_prefix . 'TODO', $defaults['TODO'] )
+				'cli_enable_safelink_filtering' => get_option( self::$options_prefix . 'cli_enable_safelink_filtering', $defaults['cli_enable_safelink_filtering'] )
 			);
 
 			$configurable_defaults = self::format_options( $configurable_defaults );

--- a/admin/class-ucf-sanitizer-config.php
+++ b/admin/class-ucf-sanitizer-config.php
@@ -438,11 +438,11 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 		}
 
 		/**
-         * Returns the installed post types as an option array
-         * @author Jim Barnes
-         * @since 1.0.0
-         * @return array
-         **/
+		 * Returns the installed post types as an option array
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @return array
+		 **/
 		public static function get_post_types_as_options() {
 			$retval = array();
 			$args = array(

--- a/admin/class-ucf-sanitizer-config.php
+++ b/admin/class-ucf-sanitizer-config.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * Defines the configuration settings
+ * for the plugin
+ */
+if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
+	/**
+	 * Class that handles plugin configuration/settings
+	 */
+	class UCF_Sanitizer_Config {
+		public static
+			/**
+			 * @var string The option prefix used
+			 */
+			$options_prefix = 'ucf_sanitizer_',
+			/**
+			 * @var array The option default values
+			 */
+			$option_defaults = array(); // TODO
+
+		/**
+		 * Creates options via the WP Options API that are utilized by the
+		 * plugin. Intended to be run on plugin activation.
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @return void
+		 */
+		public static function add_options() {
+			$defaults = self::$option_defaults;
+
+			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
+			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
+			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
+			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
+			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
+		}
+
+		/**
+		 * Deletes options via the WP Options API that are utilized by the
+		 * plugin. Intended to be run on plugin uninstallation.
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @return void
+		 */
+		public static function delete_options() {
+			// delete_option( self::$options_prefix . 'TODO' );
+			// delete_option( self::$options_prefix . 'TODO' );
+			// delete_option( self::$options_prefix . 'TODO' );
+			// delete_option( self::$options_prefix . 'TODO' );
+			// delete_option( self::$options_prefix . 'TODO' );
+		}
+
+		// /**
+		//  * Returns a list of default plugin options. Applied any overridden
+		//  * default values set within the options page.
+		//  * @author Jim Barnes
+		//  * @since 1.0.0
+		//  * @return array
+		//  */
+		// public static function get_option_defaults() {
+		// 	$defaults = self::$option_defaults;
+
+		// 	$configurable_defaults = array(
+		// 		'events_integration'      => get_option( self::$options_prefix . 'events_integration', $defaults['events_integration'] ),
+		// 		'events_base_url'         => get_option( self::$options_prefix . 'events_base_url', $defaults['events_base_url'] ),
+		// 		'events_default_feed'     => get_option( self::$options_prefix . 'events_default_feed', $defaults['events_default_feed'] ),
+		// 		'events_default_template' => get_option( self::$options_prefix . 'events_default_template', $defaults['events_default_template'] ),
+		// 		'events_default_limit'    => get_option( self::$options_prefix . 'events_default_limit', $defaults['events_default_limit'] )
+		// 	);
+
+		// 	$configurable_defaults = self::format_options( $configurable_defaults );
+		// 	$defaults = array_merge( $defaults, $configurable_defaults );
+
+		// 	return $defaults;
+		// }
+
+		// /**
+		//  * Returns an array with plugin defaults applied
+		//  * @author Jim Barnes
+		//  * @since 1.0.0
+		//  * @param array $list The list of options to apply defaults to
+		//  * @param boolean $list_keys_only Modifies results to only return array key
+		//  * 								  values present in $list.
+		//  * @return array
+		//  */
+		// public static function apply_option_defaults( $list, $list_keys_only=false ) {
+		// 	$defaults = self::get_option_defaults();
+		// 	$options = array();
+
+		// 	if ( $list_keys_only ) {
+		// 		foreach( $list as $key => $val ) {
+		// 			$options[$key] = ! empty( $val ) ? $val : $defaults[$key];
+		// 		}
+		// 	} else {
+		// 		$options = array_merge( $defaults, $list );
+		// 	}
+
+		// 	return $options;
+		// }
+
+		// /**
+		//  * Performs typecasting and sanitization on an array of plugin options.
+		//  * @author Jim Barnes
+		//  * @param array $list The list of options to format.
+		//  * @return array
+		//  */
+		// public static function format_options( $list ) {
+		// 	foreach( $list as $key => $val ) {
+		// 		switch( $key ) {
+		// 			case 'events_integration':
+		// 				$list[$key] = filter_var( $val, FILTER_VALIDATE_BOOLEAN );
+		// 				break;
+		// 			case 'events_default_limit':
+		// 				$list[$key] = filter_var( $val, FILTER_VALIDATE_INT );
+		// 				break;
+		// 			default:
+		// 				break;
+		// 		}
+		// 	}
+
+		// 	return $list;
+		// }
+
+		// /**
+		//  * Applies formatting to a single options. Intended to be passed to the
+		//  * option_{$option} hook.
+		//  * @author Jim Barnes
+		//  * @since 1.0.0
+		//  * @param mixed $value The value to be formatted
+		//  * @param string $option_name The name of the option being formatted.
+		//  * @return mixed
+		//  */
+		// public static function format_option( $value, $option_name ) {
+		// 	$option_name_no_prefix = str_replace( self::$options_prefix, '', $option_name );
+		// 	$option_formatted = self::format_options( array( $option_name_no_prefix => $value ) );
+
+		// 	return $option_formatted[$option_name_no_prefix];
+		// }
+
+		// /**
+		//  * Adds filters for plugin options that apply
+		//  * our formatting rules to option values.
+		//  * @author Jim Barnes
+		//  * @since 1.0.0
+		//  * @return void
+		//  */
+		// public static function add_option_formatting_filters() {
+		// 	$defaults = self::$option_defaults;
+
+		// 	foreach( $defaults as $option => $default ) {
+		// 		$option_name = self::$options_prefix . $option;
+		// 		add_filter( "option_{$option_name}", array( 'UCF_Sanitizer_Config', 'format_option' ), 10, 2 );
+		// 	}
+		// }
+
+		// /**
+		//  * Utility method for returning an option from the WP Options API
+		//  * or a plugin option default.
+		//  * @author Jim Barnes
+		//  * @since 1.0.0
+		//  * @param string $option_name The name of the option to retrieve.
+		//  * @return mixed
+		//  */
+		// public static function get_option_or_default( $option_name ) {
+		// 	// Handle $option_name passed in with or without self::$options_prefix applied:
+		// 	$option_name_no_prefix = str_replace( self::$options_prefix, '', $option_name );
+		// 	$option_name           = self::$options_prefix . $option_name_no_prefix;
+		// 	$defaults              = self::get_option_defaults();
+
+		// 	$default = isset( $defaults[$option_name_no_prefix] ) ? $defaults[$option_name_no_prefix] : null;
+
+		// 	return get_option( $option_name, $default );
+		// }
+
+		/**
+		 * Initializes setting registration with the Settings API.
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @return void
+		 */
+		public static function settings_init() {
+			$settings_slug = 'ucf_sanitizer_settings';
+			$defaults      = self::$option_defaults;
+			$display_fn    = array( 'UCF_Sanitizer_Config', 'display_settings_field' );
+
+			// Register all default settings.
+			foreach( $defaults as $key => $val ) {
+				register_setting(
+					$settings_slug,
+					self::$options_prefix . $key
+				);
+			}
+
+			// TODO add settings and sections
+		}
+
+		/**
+		 * Displays an individual settings's field markup.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param array The field's argument array
+		 * @return string The formatted html of the field
+		 */
+		public static function display_settings_field( $args ) {
+			$option_name = $args['label_for'];
+			$description = $args['description'];
+			$field_type  = $args['type'];
+			$options     = isset( $args['options'] ) ? $args['options'] : null;
+			$current_val = self::get_option_or_default( $option_name );
+			$markup      = '';
+
+			switch( $field_type ) {
+				case 'checkbox':
+					ob_start();
+				?>
+					<input type="checkbox" id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>"<?php echo ( $current_val === true ) ? ' checked' : ''; ?>>
+					<p class="description">
+						<?php echo $description; ?>
+					</p>
+				<?php
+					$markup = ob_get_clean();
+					break;
+				case 'checkbox-list':
+					ob_start();
+					if ( ! empty( $options ) ) :
+				?>
+					<p class="description"><strong><?php echo $description; ?></strong></p>
+					<ul class="categorychecklist">
+				<?php
+						foreach( $options as $val => $text ) :
+				?>
+					<li>
+						<label for="<?php echo $option_name . '_' . $val; ?>">
+						<input type="checkbox" id="<?php echo $option_name . '_' . $val; ?>" name="<?php echo $option_name; ?>[]"<?php echo ( in_array( $val, $current_val ) ) ? ' checked' : ''; ?> value="<?php echo $val; ?>">
+							<?php echo $text; ?>
+						</label>
+					</li>
+				<?php
+						endforeach;
+				?>
+					</ul>
+				<?php
+					else:
+				?>
+					<p class="description" style="color: red;">
+						There was an error loading the options.
+					</p>
+				<?php
+					endif;
+					$markup = ob_get_clean();
+					break;
+				case 'select':
+					ob_start();
+				?>
+					<select id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>">
+					<?php foreach( $options as $val => $text ) : ?>
+						<option value="<?php echo $val; ?>"<?php echo ( $val === $current_val ) ? ' selected' : ''; ?>>
+							<?php echo $text; ?>
+						</option>
+					<?php endforeach; ?>
+					</select>
+				<?php
+					$markup = ob_get_clean();
+					break;
+				case 'number':
+				case 'date':
+				case 'email':
+				case 'month':
+				case 'tel':
+				case 'text':
+				case 'text':
+				case 'time':
+				case 'url':
+					ob_start();
+				?>
+					<input type="<?php echo $field_type; ?>" id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>" value="<?php echo $current_val; ?>">
+					<p class="description">
+						<?php echo $description; ?>
+					</p>
+				<?php
+					$markup = ob_get_clean();
+					break;
+				case 'message':
+					ob_start();
+				?>
+					<div style="background-color: #fff; color: #000; padding: 1rem 2rem; border: 1px solid #acacac;">
+						<p><?php echo $description; ?></p>
+					</div>
+				<?php
+					$markup = ob_get_clean();
+					break;
+				default:
+				?>
+					<input type="text" id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>" value="<?php echo $current_val; ?>">
+					<p class="description">
+						<?php echo $description; ?>
+					</p>
+				<?php
+					$markup = ob_get_clean();
+					break;
+			}
+
+			echo $markup;
+		}
+
+		/**
+		 * Registers the settings page to display in the WordPress admin.
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @return string The resulting page's hook suffix.
+		 */
+		public static function add_options_page() {
+			$page_title = 'UCF Content Sanitizer Settings';
+			$menu_title = 'UCF Content Sanitizer';
+			$capability = 'manage_options';
+			$menu_slug  = 'ucf_sanitizer_settings';
+			$callback   = array( 'UCF_Sanitizer_Config', 'options_page_html' );
+
+			return add_options_page(
+				$page_title,
+				$menu_title,
+				$capability,
+				$menu_slug,
+				$callback
+			);
+		}
+
+		/**
+		 * Provides the HTML for the UCF Content Sanitizer Plugin
+		 * settings page.
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @return void Output is echoed.
+		 */
+		public static function options_page_html() {
+			ob_start();
+		?>
+			<div class="wrap">
+				<h1><?php echo get_admin_page_title(); ?></h1>
+				<form method="post" action="options.php">
+					<?php
+						settings_fields( 'ucf_sanitizer_settings' );
+						do_settings_sections( 'ucf_sanitizer_settings' );
+						submit_button();
+					?>
+				</form>
+			</div>
+		<?php
+			echo ob_get_clean();
+		}
+	}
+}

--- a/admin/class-ucf-sanitizer-config.php
+++ b/admin/class-ucf-sanitizer-config.php
@@ -16,7 +16,13 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 			/**
 			 * @var array The option default values
 			 */
-			$option_defaults = array(); // TODO
+			$option_defaults = array(
+				// 'allowed_tags_on_save'            => '',
+				'enabled_post_types'              => array( 'post', 'page' ),
+				'cli_enable_postmaster_filtering' => true,
+				'cli_enable_safelink_filtering'   => true,
+				// 'cli_enable_tag_filtering'        => true
+			);
 
 		/**
 		 * Creates options via the WP Options API that are utilized by the
@@ -28,9 +34,9 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 		public static function add_options() {
 			$defaults = self::$option_defaults;
 
-			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
-			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
-			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
+			add_option( self::$options_prefix . 'enabled_post_types', $defaults['enabled_post_types'] );
+			add_option( self::$options_prefix . 'cli_enable_postmaster_filtering', $defaults['cli_enable_postmaster_filtering'] );
+			add_option( self::$options_prefix . 'cli_enable_safelink_filtering', $defaults['cli_enable_safelink_filtering'] );
 			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
 			// add_option( self::$options_prefix . 'TODO', $defaults['TODO'] );
 		}
@@ -43,134 +49,159 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 		 * @return void
 		 */
 		public static function delete_options() {
-			// delete_option( self::$options_prefix . 'TODO' );
-			// delete_option( self::$options_prefix . 'TODO' );
-			// delete_option( self::$options_prefix . 'TODO' );
+			delete_option( self::$options_prefix . 'enabled_post_types' );
+			delete_option( self::$options_prefix . 'cli_enable_postmaster_filtering' );
+			delete_option( self::$options_prefix . 'cli_enable_safelink_filtering' );
 			// delete_option( self::$options_prefix . 'TODO' );
 			// delete_option( self::$options_prefix . 'TODO' );
 		}
 
-		// /**
-		//  * Returns a list of default plugin options. Applied any overridden
-		//  * default values set within the options page.
-		//  * @author Jim Barnes
-		//  * @since 1.0.0
-		//  * @return array
-		//  */
-		// public static function get_option_defaults() {
-		// 	$defaults = self::$option_defaults;
+		/**
+		 * Returns a list of default plugin options. Applied any overridden
+		 * default values set within the options page.
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @return array
+		 */
+		public static function get_option_defaults() {
+			$defaults = self::$option_defaults;
 
-		// 	$configurable_defaults = array(
-		// 		'events_integration'      => get_option( self::$options_prefix . 'events_integration', $defaults['events_integration'] ),
-		// 		'events_base_url'         => get_option( self::$options_prefix . 'events_base_url', $defaults['events_base_url'] ),
-		// 		'events_default_feed'     => get_option( self::$options_prefix . 'events_default_feed', $defaults['events_default_feed'] ),
-		// 		'events_default_template' => get_option( self::$options_prefix . 'events_default_template', $defaults['events_default_template'] ),
-		// 		'events_default_limit'    => get_option( self::$options_prefix . 'events_default_limit', $defaults['events_default_limit'] )
-		// 	);
+			$configurable_defaults = array(
+				'enabled_post_types' => get_option( self::$options_prefix . 'enabled_post_types', $defaults['enabled_post_types'] ),
+				'cli_enable_postmaster_filtering' => get_option( self::$options_prefix . 'cli_enable_postmaster_filtering', $defaults['cli_enable_postmaster_filtering'] ),
+				'cli_enable_safelink_filtering' => get_option( self::$options_prefix . 'cli_enable_safelink_filtering', $defaults['cli_enable_safelink_filtering'] ),
+				// 'TODO' => get_option( self::$options_prefix . 'TODO', $defaults['TODO'] ),
+				// 'TODO' => get_option( self::$options_prefix . 'TODO', $defaults['TODO'] )
+			);
 
-		// 	$configurable_defaults = self::format_options( $configurable_defaults );
-		// 	$defaults = array_merge( $defaults, $configurable_defaults );
+			$configurable_defaults = self::format_options( $configurable_defaults );
+			$defaults = array_merge( $defaults, $configurable_defaults );
 
-		// 	return $defaults;
-		// }
+			return $defaults;
+		}
 
-		// /**
-		//  * Returns an array with plugin defaults applied
-		//  * @author Jim Barnes
-		//  * @since 1.0.0
-		//  * @param array $list The list of options to apply defaults to
-		//  * @param boolean $list_keys_only Modifies results to only return array key
-		//  * 								  values present in $list.
-		//  * @return array
-		//  */
-		// public static function apply_option_defaults( $list, $list_keys_only=false ) {
-		// 	$defaults = self::get_option_defaults();
-		// 	$options = array();
+		/**
+		 * Returns an array with plugin defaults applied
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @param array $list The list of options to apply defaults to
+		 * @param boolean $list_keys_only Modifies results to only return array key
+		 * 								  values present in $list.
+		 * @return array
+		 */
+		public static function apply_option_defaults( $list, $list_keys_only=false ) {
+			$defaults = self::get_option_defaults();
+			$options = array();
 
-		// 	if ( $list_keys_only ) {
-		// 		foreach( $list as $key => $val ) {
-		// 			$options[$key] = ! empty( $val ) ? $val : $defaults[$key];
-		// 		}
-		// 	} else {
-		// 		$options = array_merge( $defaults, $list );
-		// 	}
+			if ( $list_keys_only ) {
+				foreach( $list as $key => $val ) {
+					$options[$key] = ! empty( $val ) ? $val : $defaults[$key];
+				}
+			} else {
+				$options = array_merge( $defaults, $list );
+			}
 
-		// 	return $options;
-		// }
+			return $options;
+		}
 
-		// /**
-		//  * Performs typecasting and sanitization on an array of plugin options.
-		//  * @author Jim Barnes
-		//  * @param array $list The list of options to format.
-		//  * @return array
-		//  */
-		// public static function format_options( $list ) {
-		// 	foreach( $list as $key => $val ) {
-		// 		switch( $key ) {
-		// 			case 'events_integration':
-		// 				$list[$key] = filter_var( $val, FILTER_VALIDATE_BOOLEAN );
-		// 				break;
-		// 			case 'events_default_limit':
-		// 				$list[$key] = filter_var( $val, FILTER_VALIDATE_INT );
-		// 				break;
-		// 			default:
-		// 				break;
-		// 		}
-		// 	}
+		/**
+		 * Performs typecasting and sanitization on an array of plugin options.
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @param array $list The list of options to format.
+		 * @return array
+		 */
+		public static function format_options( $list ) {
+			foreach( $list as $key => $val ) {
+				switch( $key ) {
+					// checkbox-list fields
+					case 'enabled_post_types':
+						$retval = array();
 
-		// 	return $list;
-		// }
+						if ( is_array( $val ) ) {
+							// https://stackoverflow.com/a/4254008
+							if ( count( array_filter( array_keys( $val ), 'is_string' ) ) === 0 ) {
+								// This looks like a default field value; just return it
+								$retval = $val;
+							}
+							else {
+								// This looks like a saved option value (['value' => 'on/off/""']); format it
+								foreach ( $val as $k => $v ) {
+									if ( $v === 'on' ) {
+										$retval[] = $k;
+									}
+								}
+							}
+						}
+						else {
+							$retval = array( $val );
+						}
 
-		// /**
-		//  * Applies formatting to a single options. Intended to be passed to the
-		//  * option_{$option} hook.
-		//  * @author Jim Barnes
-		//  * @since 1.0.0
-		//  * @param mixed $value The value to be formatted
-		//  * @param string $option_name The name of the option being formatted.
-		//  * @return mixed
-		//  */
-		// public static function format_option( $value, $option_name ) {
-		// 	$option_name_no_prefix = str_replace( self::$options_prefix, '', $option_name );
-		// 	$option_formatted = self::format_options( array( $option_name_no_prefix => $value ) );
+						$list[$key] = $retval;
+						break;
+					// checkbox/boolean fields
+					case 'cli_enable_postmaster_filtering':
+					case 'cli_enable_safelink_filtering':
+						$list[$key] = filter_var( $val, FILTER_VALIDATE_BOOLEAN );
+						break;
+					default:
+						break;
+				}
+			}
 
-		// 	return $option_formatted[$option_name_no_prefix];
-		// }
+			return $list;
+		}
 
-		// /**
-		//  * Adds filters for plugin options that apply
-		//  * our formatting rules to option values.
-		//  * @author Jim Barnes
-		//  * @since 1.0.0
-		//  * @return void
-		//  */
-		// public static function add_option_formatting_filters() {
-		// 	$defaults = self::$option_defaults;
+		/**
+		 * Applies formatting to a single option. Intended to be passed to the
+		 * option_{$option} hook.
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @param mixed $value The value to be formatted
+		 * @param string $option_name The name of the option being formatted.
+		 * @return mixed
+		 */
+		public static function format_option( $value, $option_name ) {
+			$option_name_no_prefix = str_replace( self::$options_prefix, '', $option_name );
+			$option_formatted = self::format_options( array( $option_name_no_prefix => $value ) );
 
-		// 	foreach( $defaults as $option => $default ) {
-		// 		$option_name = self::$options_prefix . $option;
-		// 		add_filter( "option_{$option_name}", array( 'UCF_Sanitizer_Config', 'format_option' ), 10, 2 );
-		// 	}
-		// }
+			return $option_formatted[$option_name_no_prefix];
+		}
 
-		// /**
-		//  * Utility method for returning an option from the WP Options API
-		//  * or a plugin option default.
-		//  * @author Jim Barnes
-		//  * @since 1.0.0
-		//  * @param string $option_name The name of the option to retrieve.
-		//  * @return mixed
-		//  */
-		// public static function get_option_or_default( $option_name ) {
-		// 	// Handle $option_name passed in with or without self::$options_prefix applied:
-		// 	$option_name_no_prefix = str_replace( self::$options_prefix, '', $option_name );
-		// 	$option_name           = self::$options_prefix . $option_name_no_prefix;
-		// 	$defaults              = self::get_option_defaults();
+		/**
+		 * Adds filters for plugin options that apply
+		 * our formatting rules to option values.
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @return void
+		 */
+		public static function add_option_formatting_filters() {
+			$defaults = self::$option_defaults;
 
-		// 	$default = isset( $defaults[$option_name_no_prefix] ) ? $defaults[$option_name_no_prefix] : null;
+			foreach( $defaults as $option => $default ) {
+				$option_name = self::$options_prefix . $option;
+				add_filter( "option_{$option_name}", array( 'UCF_Sanitizer_Config', 'format_option' ), 10, 2 );
+			}
+		}
 
-		// 	return get_option( $option_name, $default );
-		// }
+		/**
+		 * Utility method for returning an option from the WP Options API
+		 * or a plugin option default.
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @param string $option_name The name of the option to retrieve.
+		 * @return mixed
+		 */
+		public static function get_option_or_default( $option_name ) {
+			// Handle $option_name passed in with or without self::$options_prefix applied:
+			$option_name_no_prefix = str_replace( self::$options_prefix, '', $option_name );
+			$option_name           = self::$options_prefix . $option_name_no_prefix;
+			$defaults              = self::get_option_defaults();
+
+			$default = isset( $defaults[$option_name_no_prefix] ) ? $defaults[$option_name_no_prefix] : null;
+
+			return get_option( $option_name, $default );
+		}
 
 		/**
 		 * Initializes setting registration with the Settings API.
@@ -191,12 +222,67 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 				);
 			}
 
-			// TODO add settings and sections
+			// Register all settings sections
+			add_settings_section(
+				'ucf_sanitizer_settings_shared',
+				'Shared Settings',
+				null,
+				$settings_slug
+			);
+
+			add_settings_section(
+				'ucf_sanitizer_settings_cli',
+				'WP-CLI Command Settings',
+				null,
+				$settings_slug
+			);
+
+			// Register Shared Settings fields
+			add_settings_field(
+				self::$options_prefix . 'enabled_post_types',
+				'Enabled Post Types',
+				$display_fn,
+				$settings_slug,
+				'ucf_sanitizer_settings_shared',
+				array(
+					'label_for'   => self::$options_prefix . 'enabled_post_types',
+					'description' => 'Select one or more post types on which the plugin should perform content sanitization.',
+					'type'        => 'checkbox-list',
+					'options'     => self::get_post_types_as_options()
+				)
+			);
+
+			// Register WP CLI Command Settings fields
+			add_settings_field(
+				self::$options_prefix . 'cli_enable_postmaster_filtering',
+				'Enable Postmaster Redirect Filtering',
+				$display_fn,
+				$settings_slug,
+				'ucf_sanitizer_settings_cli',
+				array(
+					'label_for'   => self::$options_prefix . 'cli_enable_postmaster_filtering',
+					'description' => 'When checked, WP-CLI commands will replace Postmaster redirect URLs in post content with cleaned URLs.',
+					'type'        => 'checkbox'
+				)
+			);
+
+			add_settings_field(
+				self::$options_prefix . 'cli_enable_safelink_filtering',
+				'Enable Outlook Safelink Redirect Filtering',
+				$display_fn,
+				$settings_slug,
+				'ucf_sanitizer_settings_cli',
+				array(
+					'label_for'   => self::$options_prefix . 'cli_enable_safelink_filtering',
+					'description' => 'When checked, WP-CLI commands will replace Outlook Safelinks in post content with cleaned URLs.',
+					'type'        => 'checkbox'
+				)
+			);
 		}
 
 		/**
 		 * Displays an individual settings's field markup.
-		 * @author Jim Barnes
+		 * @author Jo Dickson
 		 * @since 1.0.0
 		 * @param array The field's argument array
 		 * @return string The formatted html of the field
@@ -224,7 +310,7 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 					ob_start();
 					if ( ! empty( $options ) ) :
 				?>
-					<p class="description"><strong><?php echo $description; ?></strong></p>
+					<p class="description"><?php echo $description; ?></p>
 					<ul class="categorychecklist">
 				<?php
 						foreach( $options as $val => $text ) :
@@ -274,6 +360,16 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 					ob_start();
 				?>
 					<input type="<?php echo $field_type; ?>" id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>" value="<?php echo $current_val; ?>">
+					<p class="description">
+						<?php echo $description; ?>
+					</p>
+				<?php
+					$markup = ob_get_clean();
+					break;
+				case 'textarea':
+					ob_start();
+				?>
+					<textarea id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>"><?php echo $current_val; ?></textarea>
 					<p class="description">
 						<?php echo $description; ?>
 					</p>
@@ -347,6 +443,24 @@ if ( ! class_exists( 'UCF_Sanitizer_Config' ) ) {
 			</div>
 		<?php
 			echo ob_get_clean();
+		}
+
+		/**
+         * Returns the installed post types as an option array
+         * @author Jim Barnes
+         * @since 1.0.0
+         * @return array
+         **/
+		public static function get_post_types_as_options() {
+			$retval = array();
+			$args = array(
+				'public'   => true
+			);
+			$post_types = get_post_types( $args, 'objects' );
+			foreach( $post_types as $post_type ) {
+				$retval[$post_type->name] = $post_type->label;
+			}
+			return $retval;
 		}
 	}
 }

--- a/commands/class-ucf-sanitizer-run-all.php
+++ b/commands/class-ucf-sanitizer-run-all.php
@@ -4,6 +4,17 @@
  */
 if ( ! class_exists( 'UCF_Sanitizer_Command_Sanitize_All' ) ) {
 	class UCF_Sanitizer_Command_Sanitize_All {
+		private
+			/**
+			 * @var array Set of posts to process
+			 */
+			$posts;
+
+
+		public function __construct( $args=array() ) {
+			$this->posts = UCF_Sanitizer_Common::get_posts_for_sanitization();
+		}
+
 		/**
 		 * Runs all filtering commands
 		 *
@@ -14,7 +25,9 @@ if ( ! class_exists( 'UCF_Sanitizer_Command_Sanitize_All' ) ) {
 		 * @when after_wp_load
 		 */
 		public function __invoke( $args ) {
-			$filter_content = new UCF_Sanitizer_Command_Sanitize_Content();
+			$filter_content = new UCF_Sanitizer_Command_Sanitize_Content( array(
+				'posts' => $this->posts
+			) );
 			$filter_content->__invoke( $args );
 
 			WP_CLI::success( 'Finished running all tasks.' );

--- a/commands/class-ucf-sanitizer-run-all.php
+++ b/commands/class-ucf-sanitizer-run-all.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Runs all the configured tasks.
+ */
+if ( ! class_exists( 'UCF_Sanitizer_Command_Sanitize_All' ) ) {
+	class UCF_Sanitizer_Command_Sanitize_All {
+		/**
+		 * Runs all filtering commands
+		 *
+		 * ## EXAMPLES
+		 *
+		 *     wp ucfsanitizer sanitize all
+		 *
+		 * @when after_wp_load
+		 */
+		public function __invoke( $args ) {
+			$filter_content = new UCF_Sanitizer_Command_Sanitize_Content();
+			$filter_content->__invoke( $args );
+
+			WP_CLI::success( 'Finished running all tasks.' );
+		}
+	}
+}

--- a/commands/class-ucf-sanitizer-sanitize-content.php
+++ b/commands/class-ucf-sanitizer-sanitize-content.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Performs content sanitization all at once on post content,
+ * depending on plugin settings.
+ */
+if ( ! class_exists( 'UCF_Sanitizer_Command_Sanitize_Content' ) ) {
+	class UCF_Sanitizer_Command_Sanitize_Content {
+		private
+			$progress,
+			$filtered = 0;
+
+		/**
+		 * Filters old post content to strip out undesirable tags.
+		 *
+		 * ## EXAMPLES
+		 *
+		 *     wp ucfsanitizer filter content
+		 *
+		 * @when after_wp_load
+		 */
+		public function __invoke( $args ) {
+			// TODO filter by enabled post types
+			$posts = get_posts( array(
+				'posts_per_page' => -1,
+				'post_status'    => array( 'publish', 'pending', 'draft', 'future', 'private' )
+			) );
+
+			$count = count( $posts );
+
+			$this->progress = WP_CLI\Utils\make_progress_bar(
+				"Updating Post Content...",
+				$count
+			);
+
+			foreach ( $posts as $post ) {
+				// TODO add Postmaster link filtering, if enabled
+				// TODO add Outlook Safelink filtering, if enabled
+				// TODO add on-save HTML tag filtering, if enabled
+				// TODO add action for themes/plugins to hook into here
+				$this->progress->tick();
+			}
+
+			$this->progress->finish();
+
+			WP_CLI::success( "Updated post content within $this->filtered posts out of $count processed posts." );
+		}
+	}
+}

--- a/commands/class-ucf-sanitizer-sanitize-content.php
+++ b/commands/class-ucf-sanitizer-sanitize-content.php
@@ -6,43 +6,73 @@
 if ( ! class_exists( 'UCF_Sanitizer_Command_Sanitize_Content' ) ) {
 	class UCF_Sanitizer_Command_Sanitize_Content {
 		private
+			/**
+			 * @var array Set of posts to process
+			 */
+			$posts,
+			/**
+			 * @var object Progress bar object
+			 */
 			$progress,
-			$filtered = 0;
+			/**
+			 * @var int Number of sanitized + saved posts
+			 */
+			$sanitized = 0;
+
+
+		public function __construct( $args=array() ) {
+			$this->posts = isset( $args['posts'] ) ? $args['posts'] : $this->get_posts();
+		}
 
 		/**
 		 * Filters old post content to strip out undesirable tags.
 		 *
 		 * ## EXAMPLES
 		 *
-		 *     wp ucfsanitizer filter content
+		 *     wp ucfsanitizer sanitize content
 		 *
 		 * @when after_wp_load
 		 */
 		public function __invoke( $args ) {
-			// TODO filter by enabled post types
-			$posts = get_posts( array(
-				'posts_per_page' => -1,
-				'post_status'    => array( 'publish', 'pending', 'draft', 'future', 'private' )
-			) );
-
-			$count = count( $posts );
+			global $wpdb;
+			$count = count( $this->posts );
 
 			$this->progress = WP_CLI\Utils\make_progress_bar(
 				"Updating Post Content...",
 				$count
 			);
 
-			foreach ( $posts as $post ) {
-				// TODO add Postmaster link filtering, if enabled
-				// TODO add Outlook Safelink filtering, if enabled
-				// TODO add on-save HTML tag filtering, if enabled
-				// TODO add action for themes/plugins to hook into here
+			foreach ( $this->posts as $post ) {
+				$post_content = $post->post_content;
+				$post_content = UCF_Sanitizer_Common::run_cli_sanitizers( $post_content );
+				if ( $post->post_content !== $post_content ) {
+					$update_status = $wpdb->update( $wpdb->posts, array( 'post_content' => $post_content ), array( 'ID' => $post->ID ) );
+					if ( $update_status !== false ) {
+						$this->sanitized++;
+						clean_post_cache( $post->ID );
+					}
+				}
 				$this->progress->tick();
 			}
 
 			$this->progress->finish();
 
-			WP_CLI::success( "Updated post content within $this->filtered posts out of $count processed posts." );
+			WP_CLI::success( "Updated post content within $this->sanitized posts out of $count processed posts." );
+		}
+
+		/**
+		 * Returns all post objects to be processed during this command.
+		 *
+		 * @since 1.0.0
+		 * @author Jo Dickson
+		 * @return array Array of WP_Post objects
+		 */
+		private function get_posts() {
+			if ( $this->posts ) {
+				return $this->posts;
+			}
+
+			return UCF_Sanitizer_Common::get_posts_for_sanitization();
 		}
 	}
 }

--- a/includes/class-ucf-sanitizer-common.php
+++ b/includes/class-ucf-sanitizer-common.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Utility functions
+ */
+if ( ! class_exists( 'UCF_Sanitizer_Common' ) ) {
+	/**
+	 * Common static functions used throughout the plugin
+	 * @author Jo Dickson
+	 * @since 1.0.0
+	 */
+	class UCF_Sanitizer_Common {
+
+		/**
+		 * Returns a content string with `<a>` href values sanitized
+		 * using the provided callback.
+		 *
+		 * @since 1.0.0
+		 * @author Jo Dickson
+		 * @param string $content Artitrary HTML content string
+		 * @param mixed $callback Callable function to perform on each link href value in $content
+		 * @return string Sanitized content string
+		 */
+		public static function sanitize_links( $content, $callback ) {
+			if ( is_string( $content ) ) {
+				$content = preg_replace_callback(
+					'/href=(?P<quote>\'|\")(?P<href>(?:[^\'\"])*)(?P=quote)/i',
+					function( $match ) use ( $callback ) {
+
+						$link = $match[0];
+						$href = isset( $match['href'] ) ? $match['href'] : '';
+						if ( ! $href ) return $link;
+
+						$href_clean = call_user_func_array( $callback, array( $href ) );
+
+						if ( $href_clean !== $href ) {
+							$link = str_replace( $href, $href_clean, $link );
+						}
+
+						return $link;
+
+					},
+					$content
+				);
+			}
+
+			return $content;
+		}
+
+		/**
+		 * Generic function that replaces a URL with a query param value
+		 * based on specific search criteria in the URL.  Intended for
+		 * picking out final URLs from domains that perform redirections.
+		 *
+		 * Example:
+		 * ```
+		 * strip_link_prefix(
+		 *     'https://some-redirector-domain.com/?url=https://www.ucf.edu/',
+		 *     '//^https\:\/\/some\-redirector-\domain\.com\//i/',
+		 *     'url'
+		 * );
+		 * ```
+		 * would return "https://www.ucf.edu/"
+		 *
+		 * @since 1.0.0
+		 * @author Jo Dickson
+		 * @param string $url The full URL to parse against
+		 * @param string $search_regex Regex to perform against $url using `preg_match()`
+		 * @param string $query_param Query parameter to isolate the desired URL from
+		 * @return string The filtered URL value
+		 */
+		public static function strip_link_prefix( $url, $search_regex, $query_param ) {
+			if ( preg_match( $search_regex, $url ) ) {
+				$query_params = array();
+				parse_str( parse_url( $url, PHP_URL_QUERY ), $query_params );
+				if ( isset( $query_params[$query_param] ) ) {
+					$url = urldecode( $query_params[$query_param] );
+				}
+			}
+
+			return $url;
+		}
+
+		/**
+		 * Replaces Outlook safelink URLs with the actual redirected URL.
+		 *
+		 * @since 1.0.0
+		 * @author Jo Dickson
+		 * @param string $url The full URL to parse against
+		 * @return string The filtered URL value
+		 */
+		public static function strip_outlook_safelinks( $url ) {
+			return self::strip_link_prefix(
+				$url,
+				'/^https\:\/\/(.*\.)safelinks\.protection\.outlook\.com\//i',
+				'url'
+			);
+		}
+
+		/**
+		 * Replaces Postmaster redirects with the actual redirected URL.
+		 *
+		 * @since 1.0.0
+		 * @author Jo Dickson
+		 * @param string $url The full URL to parse against
+		 * @return string The filtered URL value
+		 */
+		public static function strip_postmaster_redirects( $url ) {
+			return self::strip_link_prefix(
+				$url,
+				'/^https\:\/\/postmaster\.smca\.ucf\.edu\//i',
+				'url'
+			);
+		}
+
+		/**
+		 * Returns all eligible posts for sanitization when performing bulk
+		 * sanitization tasks.
+		 *
+		 * @since 1.0.0
+		 * @author Jo Dickson
+		 * @return array Array of WP_Post objects
+		 */
+		public static function get_posts_for_sanitization() {
+			return get_posts( array(
+				'posts_per_page' => -1,
+				'post_status'    => array( 'publish', 'pending', 'draft', 'future', 'private' ),
+				'post_type'      => UCF_Sanitizer_Config::get_option_or_default( 'enabled_post_types' )
+			) );
+		}
+
+		/**
+		 * Runs all valid WP-CLI sanitizers on the given content string,
+		 * depending on plugin settings/configuration.
+		 *
+		 * @since 1.0.0
+		 * @author Jo Dickson
+		 * @param string $content Arbitrary content to sanitize
+		 * @return string Sanitized content
+		 */
+		public static function run_cli_sanitizers( $content ) {
+			if ( UCF_Sanitizer_Config::get_option_or_default( 'cli_enable_safelink_filtering' ) === true ) {
+				$content = self::sanitize_links( $content, array( 'UCF_Sanitizer_Common', 'strip_outlook_safelinks' ) );
+			}
+			if ( UCF_Sanitizer_Config::get_option_or_default( 'cli_enable_postmaster_filtering' ) === true ) {
+				$content = self::sanitize_links( $content, array( 'UCF_Sanitizer_Common', 'strip_postmaster_redirects' ) );
+			}
+			return $content;
+		}
+
+	}
+}

--- a/ucf-content-sanitizer-plugin.php
+++ b/ucf-content-sanitizer-plugin.php
@@ -39,7 +39,7 @@ if ( ! function_exists( 'ucf_sanitizer_activation' ) ) {
 		UCF_Sanitizer_Config::add_options();
 	}
 
-	register_activation_hook( UCF_SANITIZER__FILE, 'ucf_sanitizer_activation' );
+	register_activation_hook( UCF_SANITIZER__PLUGIN_FILE, 'ucf_sanitizer_activation' );
 }
 
 if ( ! function_exists( 'ucf_sanitizer_deactivation' ) ) {
@@ -52,7 +52,7 @@ if ( ! function_exists( 'ucf_sanitizer_deactivation' ) ) {
 		UCF_Sanitizer_Config::delete_options();
 	}
 
-	register_deactivation_hook( UCF_SANITIZER__FILE, 'ucf_sanitizer_deactivation' );
+	register_deactivation_hook( UCF_SANITIZER__PLUGIN_FILE, 'ucf_sanitizer_deactivation' );
 }
 
 if ( ! function_exists( 'ucf_sanitizer_init' ) ) {
@@ -65,6 +65,9 @@ if ( ! function_exists( 'ucf_sanitizer_init' ) ) {
 		// Add admin menu item
 		add_action( 'admin_init', array( 'UCF_Sanitizer_Config', 'settings_init' ), 10, 0 );
 		add_action( 'admin_menu', array( 'UCF_Sanitizer_Config', 'add_options_page' ), 10, 0 );
+
+		// Init actions
+		add_action( 'init', array( 'UCF_Sanitizer_Config', 'add_option_formatting_filters' ), 10, 0 );
 	}
 
 	add_action( 'plugins_loaded', 'ucf_sanitizer_init', 10, 0 );

--- a/ucf-content-sanitizer-plugin.php
+++ b/ucf-content-sanitizer-plugin.php
@@ -19,6 +19,7 @@ define( 'UCF_SANITIZER__PLUGIN_FILE', __FILE__ );
 
 
 require_once 'admin/class-ucf-sanitizer-config.php';
+require_once 'includes/class-ucf-sanitizer-common.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once 'commands/class-ucf-sanitizer-sanitize-content.php';

--- a/ucf-content-sanitizer-plugin.php
+++ b/ucf-content-sanitizer-plugin.php
@@ -11,3 +11,61 @@ GitHub Plugin URI: UCF/UCF-Content-Sanitizer-Plugin
 if ( ! defined( 'WPINC' ) ) {
     die;
 }
+
+define( 'UCF_SANITIZER__PLUGIN_URL', plugins_url( basename( dirname( __FILE__ ) ) ) );
+define( 'UCF_SANITIZER__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'UCF_SANITIZER__STATIC_URL', UCF_SANITIZER__PLUGIN_URL . '/static' );
+define( 'UCF_SANITIZER__PLUGIN_FILE', __FILE__ );
+
+
+require_once 'admin/class-ucf-sanitizer-config.php';
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once 'commands/class-ucf-sanitizer-sanitize-content.php';
+	require_once 'commands/class-ucf-sanitizer-run-all.php';
+
+	WP_CLI::add_command( 'ucfsanitizer sanitize content', 'UCF_Sanitizer_Command_Sanitize_Content' );
+	WP_CLI::add_command( 'ucfsanitizer sanitize all', 'UCF_Sanitizer_Command_Sanitize_All' );
+}
+
+
+if ( ! function_exists( 'ucf_sanitizer_activation' ) ) {
+	/**
+	 * Function that runs on plugin activation
+	 * @author Jo Dickson
+	 * @since 1.0.0
+	 */
+	function ucf_sanitizer_activation() {
+		UCF_Sanitizer_Config::add_options();
+	}
+
+	register_activation_hook( UCF_SANITIZER__FILE, 'ucf_sanitizer_activation' );
+}
+
+if ( ! function_exists( 'ucf_sanitizer_deactivation' ) ) {
+	/**
+	 * Function that runs on plugin deactivation
+	 * @author Jo Dickson
+	 * @since 1.0.0
+	 */
+	function ucf_sanitizer_deactivation() {
+		UCF_Sanitizer_Config::delete_options();
+	}
+
+	register_deactivation_hook( UCF_SANITIZER__FILE, 'ucf_sanitizer_deactivation' );
+}
+
+if ( ! function_exists( 'ucf_sanitizer_init' ) ) {
+	/**
+	 * Function that runs when all plugins are loaded
+	 * @author Jo Dickson
+	 * @since 1.0.0
+	 */
+	function ucf_sanitizer_init() {
+		// Add admin menu item
+		add_action( 'admin_init', array( 'UCF_Sanitizer_Config', 'settings_init' ), 10, 0 );
+		add_action( 'admin_menu', array( 'UCF_Sanitizer_Config', 'add_options_page' ), 10, 0 );
+	}
+
+	add_action( 'plugins_loaded', 'ucf_sanitizer_init', 10, 0 );
+}


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Content-Sanitizer-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Content-Sanitizer-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Adds initial WP CLI commands for sanitizing post content for Outlook Safelinks and Postmaster redirects.

There's some structural changes with how functions are defined, but overall the Safelink and Postmaster URL filtering behaves the same as in the Today Migration plugin's content migrator.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of version 1.0.0.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested locally and in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
